### PR TITLE
Fix Coleman–Liau warning message

### DIFF
--- a/Readability/ColemanLiau.yml
+++ b/Readability/ColemanLiau.yml
@@ -1,5 +1,5 @@
 extends: metric
-message: "Try to keep the Coleman–Liau Index grade (%s) below 19."
+message: "Try to keep the Coleman–Liau Index grade (%s) below 9."
 link: https://en.wikipedia.org/wiki/Coleman%E2%80%93Liau_index
 
 formula: |


### PR DESCRIPTION
Condition for Coleman–Liau is `< 9`, but the message is for 'below 19'. Given it's supposed to be a measure of grades, I assume it's the warning message that's in error.